### PR TITLE
Update glide library to 4.6.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.github.bumptech.glide:glide:4.5.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.5.0'
+    implementation 'com.github.bumptech.glide:glide:4.6.1'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
     implementation 'com.caverock:androidsvg:1.2.1'
 }


### PR DESCRIPTION
Maybe it's better to remove glide dependencies from the project completely and use them external like:
```
dependencies {
  implementation 'com.github.firdausmaulan:GlideSlider:1.3.0'
  implementation 'com.github.bumptech.glide:glide:4.6.1'
  annotationProcessor 'com.github.bumptech.glide:compiler:4.6.1'
}
```
So we can use the latest glide every time without need to update the GlideSlider