### PR TITLE
Properly configure library dependencies and remove unnecessary printStackTrace() call.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,6 +9,11 @@ android {
         targetSdkVersion 27
         versionCode 15
         versionName "1.3.2"
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ['library': 'true']
+            }
+        }
     }
     buildTypes {
         release {
@@ -23,7 +28,7 @@ android {
 
 dependencies {
     //noinspection GradleCompatible
-    implementation "com.android.support:appcompat-v7:$support_version"
-    implementation "com.github.bumptech.glide:glide:$glide_version"
+    api "com.android.support:appcompat-v7:$support_version"
+    api "com.github.bumptech.glide:glide:$glide_version"
     annotationProcessor "com.github.bumptech.glide:compiler:$glide_version"
 }

--- a/library/src/main/java/com/glide/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/glide/slider/library/SliderTypes/BaseSliderView.java
@@ -181,10 +181,9 @@ public abstract class BaseSliderView {
     protected void bindEventAndShow(final View v, AppCompatImageView targetImageView) {
         final BaseSliderView me = this;
 
-        try {
-            v.findViewById(R.id.glide_slider_background).setBackgroundColor(mBackgroundColor);
-        } catch (NullPointerException ignored) {
-
+        final View sliderBackground = v.findViewById(R.id.glide_slider_background);
+        if (sliderBackground != null) {
+            sliderBackground.setBackgroundColor(mBackgroundColor);
         }
 
         v.setOnClickListener(new View.OnClickListener() {

--- a/library/src/main/java/com/glide/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/glide/slider/library/SliderTypes/BaseSliderView.java
@@ -183,8 +183,8 @@ public abstract class BaseSliderView {
 
         try {
             v.findViewById(R.id.glide_slider_background).setBackgroundColor(mBackgroundColor);
-        } catch (NullPointerException e) {
-            e.printStackTrace();
+        } catch (NullPointerException ignored) {
+
         }
 
         v.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
The current dependency declaration in the library introduces a conflict between the generated Glide code for the library and app. 
My app fails with: `ClassCastException: com.glide.slider.library.svg.GlideRequests cannot be cast to com.myapp.GlideRequests` when using Glide in other parts of my app. This PR fixes that.

This PR also removes the unnecessary `printStackTrace()` call when the library tries to set a background color and does not find a view with id `R.id.glide_slider_background`
This only litters the logcat with unneeded infornation.